### PR TITLE
Make FileSystemEvent constructor public

### DIFF
--- a/src/main/java/rx/fileutils/FileSystemEvent.java
+++ b/src/main/java/rx/fileutils/FileSystemEvent.java
@@ -21,7 +21,7 @@ public class FileSystemEvent {
 
     private Path path;
 
-    FileSystemEvent(WatchEvent event) {
+    public FileSystemEvent(WatchEvent event) {
         WatchEvent.Kind kind = event.kind();
         if (StandardWatchEventKinds.OVERFLOW != kind) {
             this.path = (Path) event.context();


### PR DESCRIPTION
It is useful to create your own FileSystemEvent, for example, if you want to generate fake FS event for already present file.
